### PR TITLE
add template keyword

### DIFF
--- a/src/core/matrix.hpp
+++ b/src/core/matrix.hpp
@@ -259,7 +259,7 @@ void Matrix<E, IdType>::operate(MALGORITHM &algorithm,
 		inVector->resize(size());
 	}
 
-	worker->operate<VSource, VDestination>(algorithm);
+	worker->template operate<VSource, VDestination>(algorithm);
 
 	worker->set_default_destination_field(0);
 	worker->set_default_source_field(0);


### PR DESCRIPTION
seems like g++ 7 needs this disambiguation to build m-flash.